### PR TITLE
change logging of errors during sendData() to prevent log pollution o…

### DIFF
--- a/moskito-central-connectors/moskito-central-connectors-common/src/main/java/org/moskito/central/connectors/AbstractCentralConnector.java
+++ b/moskito-central-connectors/moskito-central-connectors-common/src/main/java/org/moskito/central/connectors/AbstractCentralConnector.java
@@ -71,7 +71,11 @@ public abstract class AbstractCentralConnector extends AbstractMoskitoPlugin imp
 		try {
 			sendData(centralSnapshot);
 		} catch (Exception e) {
-			log.error(this.getClass().getSimpleName() + ".sendData() failed", e);
+			if(log.isDebugEnabled()) {
+				log.error(this.getClass().getSimpleName() + ".sendData() failed", e);
+			} else {
+				log.error(this.getClass().getSimpleName() + ".sendData() failed: " + e.getMessage());
+			}
 		}
 	}
 


### PR DESCRIPTION
The sendData() might fail repeatedly on highly loaded systems, leading to log pollution of stacktraces.
Commit reduces the error logging in these cases.